### PR TITLE
Atualização do link do exemplo

### DIFF
--- a/lessons/07.md
+++ b/lessons/07.md
@@ -32,7 +32,7 @@ Para isso, te apresento a funcionalidade [`.invoke()`](https://docs.cypress.io/a
 
 Com a funcionalidade `invoke()`, você pode fazer o seguinte, por exemplo: `cy.get('#link-que-abre-em-outra-aba').invoke('removeAttr', 'target')`.
 
-Veja [este exemplo](https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js#L70), direto de uma "receita" criada pelo time do Cypress.
+Veja [este exemplo](https://github.com/cypress-io/cypress-example-recipes/blob/66b09537649f48b7571619fa3204217c4d6f2935/examples/testing-dom__tab-handling-links/cypress/e2e/tab_handling_anchor_links_spec.cy.js#L70), direto de uma "receita" criada pelo time do Cypress.
 
 > 👨‍🏫 Vale comentar que, para tal alternativa funcionar, a página que normalmente abre em outra aba deve estar no mesmo domínio (ou sub-domínio) da aplicação em teste.
 


### PR DESCRIPTION
Com atualização para o Cypress 10, agora temos o ``spec.cy.js`` nos links e menos ramificações.