### PR TITLE
New parameters for Github-Action Cypress

### DIFF
--- a/lessons/10.md
+++ b/lessons/10.md
@@ -30,14 +30,14 @@ name: End-to-end tests 🧪
 on: [push]
 jobs:
   cypress-run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
 ```
 
 **Referência:** https://github.com/cypress-io/github-action#basic


### PR DESCRIPTION
- change runs-on ubuntu version 20.04 to 22.04 
- change actions/checkout@v2 to actions/checkout@v3
- change uses cypress-io/github-action@v2 to cypress-io/github-action@v5

Reference new https://github.com/cypress-io/github-action#basic

PS: Desculpa o inglês simples...rs